### PR TITLE
Update garrison call for new patch API

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -174,7 +174,7 @@ local events = {
 local function UpdateFromBuildings()
     ResetBodyguard()
     bodyguard.loaded_from_building = true
-    local buildings = C_Garrison.GetBuildings()
+    local buildings = C_Garrison.GetBuildings(LE_GARRISON_TYPE_6_0)
     for i = 1, #buildings do
         local building = buildings[i]
         local building_id = building.buildingID


### PR DESCRIPTION
Never submitted a pull request before, thought I'd give it a try.  Love both the LibBodyguard-1.0 and BodyGuardHealth addons.  Unfortunately they've broken with the latest 7.0.3 pre-Legion patch.

I take no credit for this fix, I found a solution by KanadiaN here:
https://mods.curse.com/addons/wow/bodyguardhealth#c61
I implemented the 1-line change, and it seems to work again.

It would be great if you could update both addons so I can use the official versions from Curse.  At the moment I've had to edit this line manually, which means it will break again if the addon updates/refreshes itself.
