### PR TITLE
Fix for C_Garrison.GetFollowers returning null

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -266,10 +266,12 @@ local function UpdateFromClassHall()
 
     local follower
 
-    for _, f in pairs(followers) do
-        if LEGION_BODYGUARDS[f.garrFollowerID] or LEGION_SPELLS[f.zoneSupportSpellID] then
-            follower = f
-            break
+    if followers then
+        for _, f in pairs(followers) do
+            if LEGION_BODYGUARDS[f.garrFollowerID] or LEGION_SPELLS[f.zoneSupportSpellID] then
+                follower = f
+                break
+            end
         end
     end
 


### PR DESCRIPTION
I discovered that you could get null back from GetFollowers when I had the addon active on my level 100 druid (without a class hall).
